### PR TITLE
refactor: custom payload types for containers 

### DIFF
--- a/packages/privmx-webendpoint-sdk/src/clients/ContextClients/ContextInboxes.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/ContextClients/ContextInboxes.ts
@@ -1,16 +1,9 @@
 import { EventDispatcher } from '../../EventDispatcher';
-import {
-    EndpointApiEvent,
-    FilesConfig,
-    Inbox,
-    InboxEntry,
-    ListOptions,
-    PagingList,
-    UserWithPubKey
-} from '../../types';
+import { EndpointApiEvent, Inbox, InboxEntry, ListOptions, PagingList } from '../../types';
 import { EventsByChannel, InboxEvents, SubscribeForChannel } from '../../types/events';
 import { InboxClient } from '../InboxClient';
 import { Endpoint } from '../Endpoint';
+import { CreateInboxPayload } from '../../types/inboxes';
 
 /**
  * Provides a wrapper for functions used to manage Inboxes in given Context.
@@ -51,14 +44,7 @@ export class ContextInboxes {
      * @returns {Promise<string>} Created Inbox ID
      */
 
-    async new(newInbox: {
-        contextId: string;
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-        filesConfig?: FilesConfig;
-    }) {
+    async new(newInbox: CreateInboxPayload) {
         const api = await this._endpoint.getInboxApi();
 
         return await InboxClient.createInbox(api, {

--- a/packages/privmx-webendpoint-sdk/src/clients/ContextClients/ContextStores.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/ContextClients/ContextStores.ts
@@ -1,16 +1,9 @@
 import { EventDispatcher } from '../../EventDispatcher';
-import {
-    EndpointApiEvent,
-    ListOptions,
-    PagingList,
-    PrivmxFile,
-    Store,
-    UserWithPubKey
-} from '../../types';
+import { EndpointApiEvent, ListOptions, PagingList, PrivmxFile, Store } from '../../types';
 import { EventsByChannel, StoreEvents, SubscribeForChannel } from '../../types/events';
 import { Endpoint } from '../Endpoint';
 import { StoreClient } from '../StoreClient';
-import { StoreFilePayload } from '../../types/store';
+import { CreateStorePayload, StoreFilePayload } from '../../types/store';
 import { StreamReader } from '../StreamReader';
 
 /**
@@ -50,13 +43,7 @@ export class ContextStores {
      *
      * @returns {Promise<string>} ID of the created Store
      */
-    async new(info: {
-        contextId: string;
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-    }): Promise<string> {
+    async new(info: CreateStorePayload): Promise<string> {
         const api = await this._endpoint.getStoreApi();
 
         return await StoreClient.createStore(api, { ...info });

--- a/packages/privmx-webendpoint-sdk/src/clients/ContextClients/ContextThreads.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/ContextClients/ContextThreads.ts
@@ -1,6 +1,7 @@
 import { EventDispatcher } from '../../EventDispatcher';
-import { ListOptions, Message, PagingList, Thread, UserWithPubKey } from '../../types';
+import { ListOptions, Message, PagingList, Thread } from '../../types';
 import { EventsByChannel, SubscribeForChannel, ThreadEvents } from '../../types/events';
+import { CreateThreadPayload } from '../../types/thread';
 import { Endpoint } from '../Endpoint';
 import { ThreadClient } from '../ThreadClient';
 
@@ -39,13 +40,7 @@ export class ContextThreads {
      * @param {Uint8Array} newThread.privateMeta - private metadata of the Thread
      * @returns {Promise<string>} - ID of created Thread
      */
-    async new(newThread: {
-        contextId: string;
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-    }): Promise<string> {
+    async new(newThread: CreateThreadPayload): Promise<string> {
         const api = await this._endpoint.getThreadApi();
         return await ThreadClient.createThread(api, {
             ...newThread

--- a/packages/privmx-webendpoint-sdk/src/clients/ContextClients/GenericInbox.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/ContextClients/GenericInbox.ts
@@ -1,14 +1,6 @@
-import {
-    EndpointApiEvent,
-    FilesConfig,
-    Inbox,
-    InboxEntry,
-    ListOptions,
-    PagingList,
-    UserWithPubKey
-} from '../../types';
+import { EndpointApiEvent, Inbox, InboxEntry, ListOptions, PagingList } from '../../types';
 import { EventsByChannel, InboxEntryEvents, SubscribeForChannel } from '../../types/events';
-import { InboxEntryPayload } from '../../types/inboxes';
+import { InboxEntryPayload, UpdateInboxPayload } from '../../types/inboxes';
 import { InboxClient } from '../InboxClient';
 
 export class GenericInbox {
@@ -47,18 +39,7 @@ export class GenericInbox {
      * @param {boolean} [updatedData.options.forceGenerateNewKey] - optional flag to allow new users to access old data
      * @returns {Promise<void>} a promise that resolves with void
      */
-    async update(updatedData: {
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-        filesConfig?: FilesConfig;
-        version: number;
-        options?: {
-            force?: boolean;
-            forceGenerateNewKey?: boolean;
-        };
-    }) {
+    async update(updatedData: UpdateInboxPayload) {
         return await this._inboxClient.updateInbox(updatedData);
     }
 

--- a/packages/privmx-webendpoint-sdk/src/clients/ContextClients/GenericStore.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/ContextClients/GenericStore.ts
@@ -1,13 +1,6 @@
-import {
-    EndpointApiEvent,
-    ListOptions,
-    PagingList,
-    PrivmxFile,
-    Store,
-    UserWithPubKey
-} from '../../types';
+import { EndpointApiEvent, ListOptions, PagingList, PrivmxFile, Store } from '../../types';
 import { EventsByChannel, StoreFileEvents, SubscribeForChannel } from '../../types/events';
-import { StoreFilePayload } from '../../types/store';
+import { StoreFilePayload, UpdateStorePayload } from '../../types/store';
 import { FileUploader } from '../FileUploader';
 import { StoreClient } from '../StoreClient';
 
@@ -48,17 +41,7 @@ export class GenericStore {
      * @param {boolean} [newStore.options.forceGenerateNewKey] - optional flag allowing new users to access old data
      * @returns {Promise<void>} promise that resolves when the Store update is complete
      */
-    async update(newStore: {
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-        version: number;
-        options?: {
-            force?: boolean;
-            forceGenerateNewKey?: boolean;
-        };
-    }): Promise<void> {
+    async update(newStore: UpdateStorePayload): Promise<void> {
         return await this._storeClient.storeUpdate(newStore);
     }
 

--- a/packages/privmx-webendpoint-sdk/src/clients/ContextClients/GenericThread.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/ContextClients/GenericThread.ts
@@ -1,6 +1,6 @@
-import { ListOptions, Message, PagingList, Thread, UserWithPubKey } from '../../types';
+import { ListOptions, Message, PagingList, Thread } from '../../types';
 import { EventsByChannel, SubscribeForChannel, ThreadMessageEvents } from '../../types/events';
-import { ThreadMessagePayload } from '../../types/thread';
+import { ThreadMessagePayload, UpdateThreadPayload } from '../../types/thread';
 import { ThreadClient } from '../ThreadClient';
 
 export class GenericThread {
@@ -39,17 +39,7 @@ export class GenericThread {
      *
      * @returns {Promise<void>} void
      */
-    async update(updatedData: {
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-        version: number;
-        options?: {
-            force?: boolean;
-            forceGenerateNewKey?: boolean;
-        };
-    }): Promise<void> {
+    async update(updatedData: UpdateThreadPayload): Promise<void> {
         return await this._threadClient.updateThread(updatedData);
     }
 

--- a/packages/privmx-webendpoint-sdk/src/clients/InboxClient.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/InboxClient.ts
@@ -3,13 +3,11 @@ import { StoreApi } from '../api/store/StoreApi';
 import { EventDispatcher } from '../EventDispatcher';
 import {
     EndpointApiEvent,
-    FilesConfig,
     Inbox,
     InboxEntry,
     InboxPublicView,
     ListOptions,
-    PagingList,
-    UserWithPubKey
+    PagingList
 } from '../types';
 import {
     Channel,
@@ -18,7 +16,7 @@ import {
     InboxEvents,
     SubscribeForChannel
 } from '../types/events';
-import { InboxEntryPayload } from '../types/inboxes';
+import { CreateInboxPayload, InboxEntryPayload, UpdateInboxPayload } from '../types/inboxes';
 import { InboxFileUploader } from './InboxFileUploader';
 import { Endpoint } from './Endpoint';
 import { FILE_MAX_CHUNK_SIZE } from '../utils/const';
@@ -61,17 +59,7 @@ export class InboxClient {
      * @param {FilesConfig} newInbox.filesConfig object to override default file configuration
      * @returns {Promise<string>} Created Inbox ID
      */
-    public static async createInbox(
-        api: InboxApi,
-        newInbox: {
-            contextId: string;
-            users: UserWithPubKey[];
-            managers: UserWithPubKey[];
-            publicMeta?: Uint8Array;
-            privateMeta?: Uint8Array;
-            filesConfig?: FilesConfig;
-        }
-    ): Promise<string> {
+    public static async createInbox(api: InboxApi, newInbox: CreateInboxPayload): Promise<string> {
         const meta = {
             publicMeta: newInbox.publicMeta || new Uint8Array(),
             privateMeta: newInbox.privateMeta || new Uint8Array()
@@ -156,18 +144,7 @@ export class InboxClient {
      * @param {boolean} [updatedData.options.forceGenerateNewKey] - optional flag to allow new users to access old data
      * @returns {Promise<void>}
      */
-    public async updateInbox(updatedData: {
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-        filesConfig?: FilesConfig;
-        version: number;
-        options?: {
-            force?: boolean;
-            forceGenerateNewKey?: boolean;
-        };
-    }): Promise<void> {
+    public async updateInbox(updatedData: UpdateInboxPayload): Promise<void> {
         const api = await this.getApi();
 
         const meta = {

--- a/packages/privmx-webendpoint-sdk/src/clients/StoreClient.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/StoreClient.ts
@@ -8,8 +8,8 @@ import {
     StoreFileEvents,
     SubscribeForChannel
 } from '../types/events';
-import { EndpointApiEvent, PrivmxFile, Store, UserWithPubKey } from '../types/index';
-import { StoreFilePayload } from '../types/store';
+import { EndpointApiEvent, PrivmxFile, Store } from '../types/index';
+import { CreateStorePayload, StoreFilePayload, UpdateStorePayload } from '../types/store';
 import { FILE_MAX_CHUNK_SIZE } from '../utils/const';
 import { Endpoint } from './Endpoint';
 import { FileUploader } from './FileUploader';
@@ -72,16 +72,7 @@ export class StoreClient {
      *
      * @returns {Promise<string>} ID of the created Store
      */
-    static async createStore(
-        api: StoreApi,
-        newStore: {
-            contextId: string;
-            users: UserWithPubKey[];
-            managers: UserWithPubKey[];
-            publicMeta?: Uint8Array;
-            privateMeta?: Uint8Array;
-        }
-    ): Promise<string> {
+    static async createStore(api: StoreApi, newStore: CreateStorePayload): Promise<string> {
         const meta = {
             publicMeta: newStore.publicMeta || new Uint8Array(),
             privateMeta: newStore.privateMeta || new Uint8Array()
@@ -499,17 +490,7 @@ export class StoreClient {
      * @returns {Promise<void>} A promise that resolves when the Store update is complete.
      */
 
-    async storeUpdate(newStore: {
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-        version: number;
-        options?: {
-            force?: boolean;
-            forceGenerateNewKey?: boolean;
-        };
-    }): Promise<void> {
+    async storeUpdate(newStore: UpdateStorePayload): Promise<void> {
         const api = await this.getApi();
 
         const meta = {

--- a/packages/privmx-webendpoint-sdk/src/clients/ThreadClient.ts
+++ b/packages/privmx-webendpoint-sdk/src/clients/ThreadClient.ts
@@ -1,13 +1,6 @@
 import { ThreadApi } from '../api/thread/ThreadApi';
 import { EventDispatcher } from '../EventDispatcher';
-import {
-    EndpointApiEvent,
-    ListOptions,
-    Message,
-    PagingList,
-    Thread,
-    UserWithPubKey
-} from '../types';
+import { EndpointApiEvent, ListOptions, Message, PagingList, Thread } from '../types';
 import {
     Channel,
     EventsByChannel,
@@ -16,7 +9,7 @@ import {
     ThreadMessageEvents
 } from '../types/events';
 import { Endpoint } from './Endpoint';
-import { ThreadMessagePayload } from '../types/thread';
+import { CreateThreadPayload, ThreadMessagePayload, UpdateThreadPayload } from '../types/thread';
 
 /**
  * Helper wrapper around raw Wasm bindings. Manages all the necessary IDs exposing high level Threads API.
@@ -62,13 +55,7 @@ export class ThreadClient {
      */
     static async createThread(
         threadApi: ThreadApi,
-        newThread: {
-            contextId: string;
-            users: UserWithPubKey[];
-            managers: UserWithPubKey[];
-            publicMeta?: Uint8Array;
-            privateMeta?: Uint8Array;
-        }
+        newThread: CreateThreadPayload
     ): Promise<string> {
         const meta = {
             publicMeta: newThread.publicMeta || new Uint8Array(),
@@ -143,17 +130,7 @@ export class ThreadClient {
      * @param {boolean} [updatedData.options.force] - optional flag to generate a new key ID for the Thread
      * @param {boolean} [updatedData.options.forceGenerateNewKey] - optional flag allowing new users to access old data
      */
-    async updateThread(updatedData: {
-        users: UserWithPubKey[];
-        managers: UserWithPubKey[];
-        publicMeta?: Uint8Array;
-        privateMeta?: Uint8Array;
-        version: number;
-        options?: {
-            force?: boolean;
-            forceGenerateNewKey?: boolean;
-        };
-    }) {
+    async updateThread(updatedData: UpdateThreadPayload) {
         const api = await this.getApi();
 
         const meta = {

--- a/packages/privmx-webendpoint-sdk/src/types/generics.ts
+++ b/packages/privmx-webendpoint-sdk/src/types/generics.ts
@@ -1,0 +1,21 @@
+import { UserWithPubKey } from './core';
+
+export interface CreateContainerPayload {
+    contextId: string;
+    users: UserWithPubKey[];
+    managers: UserWithPubKey[];
+    publicMeta?: Uint8Array;
+    privateMeta?: Uint8Array;
+}
+
+export interface UpdateContainerPayload {
+    users: UserWithPubKey[];
+    managers: UserWithPubKey[];
+    publicMeta?: Uint8Array;
+    privateMeta?: Uint8Array;
+    version: number;
+    options?: {
+        force?: boolean;
+        forceGenerateNewKey?: boolean;
+    };
+}

--- a/packages/privmx-webendpoint-sdk/src/types/inboxes.ts
+++ b/packages/privmx-webendpoint-sdk/src/types/inboxes.ts
@@ -1,3 +1,4 @@
+import { CreateContainerPayload, UpdateContainerPayload } from './generics';
 import { PrivmxFile } from './store';
 
 /**
@@ -210,4 +211,12 @@ export interface InboxEntryPayload {
          */
         data: Uint8Array | File;
     }>;
+}
+
+export interface CreateInboxPayload extends CreateContainerPayload {
+    filesConfig?: FilesConfig;
+}
+
+export interface UpdateInboxPayload extends UpdateContainerPayload {
+    filesConfig?: FilesConfig;
 }

--- a/packages/privmx-webendpoint-sdk/src/types/store.ts
+++ b/packages/privmx-webendpoint-sdk/src/types/store.ts
@@ -1,3 +1,5 @@
+import { CreateContainerPayload, UpdateContainerPayload } from './generics';
+
 /**
  * Information about a file on the server.
  */
@@ -201,3 +203,9 @@ export interface StoreFilePayload {
      */
     data: Uint8Array;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface CreateStorePayload extends CreateContainerPayload {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UpdateStorePayload extends UpdateContainerPayload {}

--- a/packages/privmx-webendpoint-sdk/src/types/thread.ts
+++ b/packages/privmx-webendpoint-sdk/src/types/thread.ts
@@ -1,3 +1,5 @@
+import { CreateContainerPayload, UpdateContainerPayload } from './generics';
+
 /**
  * Represents information about the location of given message on the server.
  */
@@ -196,3 +198,9 @@ export interface ThreadMessagePayload {
      */
     data: Uint8Array;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface CreateThreadPayload extends CreateContainerPayload {}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface UpdateThreadPayload extends UpdateContainerPayload {}


### PR DESCRIPTION
- created `CreateContainerPayload` and `UpdateContainerPayload` for reusable types between containers
- created types that extend them for specific containers [`thread`, `store`, `inbox`]
- refactored clients to use those types

closes #7 